### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release & Deploy
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/cubexy/ctrl-knit/security/code-scanning/1](https://github.com/cubexy/ctrl-knit/security/code-scanning/1)

To fix the lack of an explicit `permissions` block, add a `permissions` entry set to `contents: read` (the minimum required for workflows to fetch code) at the top level of the workflow file, just below the workflow `name:` declaration and before `on:`. This ensures that all jobs in the workflow (or specifically `build-and-push`) will be restricted to the minimal needed repository permissions, unless individual jobs explicitly ask for more. Given the workflow only checks out code and pushes to the registry using a separate secret, `contents: read` is sufficient and safest.  
**Steps:**  
- Edit `.github/workflows/release.yml`.
- Insert a `permissions:` block just after the `name:` line (line 1, before `on:` line 3).
- Set `permissions: contents: read`.
